### PR TITLE
feat: create filter & selection table

### DIFF
--- a/src/components/Main/index.js
+++ b/src/components/Main/index.js
@@ -1,5 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { fetchPropertyDetails } from "../../api";
+import {
+  fetchProperties,
+  fetchPropertyDetails,
+  getAvailablePropertyTypes
+} from "../../api";
 import Search from "../Search";
 import SearchResults from "../SearchResults";
 import SelectedProperties from "../SelectedProperties";
@@ -7,8 +11,13 @@ import PropertyTypes from "../PropertyTypes";
 
 const Main = () => {
   const [searchTerm, setSearchTerm] = useState("");
-  const [properties, setProperties] = useState([]);
   const [searchResult, setSearchResult] = useState("");
+  const [properties, setProperties] = useState([]);
+  const [selectedProperties, setSelectedProperties] = useState([]);
+  const [filteredPropertyTypes, setFilteredPropertyTypes] = useState([]);
+  const [propertyTypes, setPropertyTypes] = useState([]);
+  const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const handleSearchTerm = (e) => {
     setSearchTerm(e.target.value);
@@ -18,17 +27,49 @@ const Main = () => {
     setSearchTerm("");
   };
 
-  let arr = [];
+  const handleCheckBoxClick = (property, checked) => {
+    if (checked) {
+      setSelectedProperties([...selectedProperties, property]);
+    }
+    if (selectedProperties.includes(property)) {
+      const withoutDuplicate = selectedProperties.filter(
+        (selectedProp) => selectedProp !== property
+      );
+      setSelectedProperties(withoutDuplicate);
+    }
+  };
+
+  const getPropertyTypes = async () => {
+    const result = await getAvailablePropertyTypes();
+    setPropertyTypes(result.propertyTypes);
+  };
+
+  const searchProperties = (e) => {
+    e.preventDefault();
+    setSearchTerm("");
+    fetchProperties({ address: searchTerm }).then((data) => {
+      setSearchResult(data.properties);
+    });
+  };
 
   useEffect(() => {
-    if (searchResult.length > 0) {
-      searchResult.forEach((property) => {
-        fetchPropertyDetails(property.id).then((res) => {
-          arr = [...arr, res.property];
-          setProperties(arr);
+    getPropertyTypes();
+    setError(false);
+    setLoading(true);
+    try {
+      let result = [];
+      if (searchResult.length > 0) {
+        searchResult.forEach((property) => {
+          fetchPropertyDetails(property.id).then((res) => {
+            result = [...result, res.property];
+            setProperties(result);
+          });
         });
-      });
+      }
+    } catch (error) {
+      setError(true);
     }
+    setLoading(false);
   }, [searchResult]);
 
   return (
@@ -41,38 +82,55 @@ const Main = () => {
             handleClearSearchTerm={handleClearSearchTerm}
             handleSearchTerm={handleSearchTerm}
             setSearchResult={setSearchResult}
+            searchProperties={searchProperties}
           />
         </section>
-        <section className="selected-section">
-          <SelectedProperties
-            properties={properties}
-            title={"Selected properties"}
-            headingColumns={[
-              "Address",
-              "Postcode",
-              "Property type",
-              "Number of rooms",
-              "Floor area (m2)"
-            ]}
-          />
-        </section>
-        <section className="table-section">
-          <SearchResults
-            properties={properties}
-            title={"Search results"}
-            headingColumns={[
-              "✓",
-              "Address",
-              "Postcode",
-              "Property type",
-              "Number of rooms",
-              "Floor area (m2)"
-            ]}
-          />
-        </section>
-        <section className="types-section">
-          <PropertyTypes />
-        </section>
+        {error && (
+          <div className="selected-section">Something went wrong ...</div>
+        )}
+        {loading ? (
+          <div className="selected-section">Loading ...</div>
+        ) : (
+          <>
+            <section className="selected-section">
+              <SelectedProperties
+                properties={properties}
+                title={"Selected properties"}
+                selectedProperties={selectedProperties}
+                headingColumns={[
+                  "Address",
+                  "Postcode",
+                  "Property type",
+                  "Number of rooms",
+                  "Floor area (m2)"
+                ]}
+              />
+            </section>
+            <section className="table-section">
+              <SearchResults
+                properties={properties}
+                filteredPropertyTypes={filteredPropertyTypes}
+                title={"Search results"}
+                handleCheckBoxClick={handleCheckBoxClick}
+                headingColumns={[
+                  "✓",
+                  "Address",
+                  "Postcode",
+                  "Property type",
+                  "Number of rooms",
+                  "Floor area (m2)"
+                ]}
+              />
+            </section>
+            <section className="types-section">
+              <PropertyTypes
+                propertyTypes={propertyTypes}
+                properties={properties}
+                setFilteredPropertyTypes={setFilteredPropertyTypes}
+              />
+            </section>
+          </>
+        )}
       </main>
     </>
   );

--- a/src/components/PropertyTypes/index.js
+++ b/src/components/PropertyTypes/index.js
@@ -1,14 +1,51 @@
 import React from "react";
 
-const PropertyTypes = () => {
+const PropertyTypes = ({
+  propertyTypes,
+  properties,
+  setFilteredPropertyTypes
+}) => {
+  const handlePropertyFilters = (types) => {
+    const filteredProps = properties.filter((property) => {
+      if (types === "All") {
+        return properties;
+      } else {
+        return property.propertyType === types;
+      }
+    });
+    setFilteredPropertyTypes(filteredProps);
+  };
+
   return (
     <>
-      <h2 className="property-title">Search results</h2>
+      <h2 className="property-title">Property types</h2>
       <ul className="property-list">
-        <li>1</li>
-        <li>2</li>
-        <li>3</li>
-        <li>4</li>
+        <li>
+          <button
+            className="property-list-btn"
+            onClick={(e) => {
+              handlePropertyFilters("All");
+            }}
+          >
+            All
+          </button>
+        </li>
+        {propertyTypes.map((propertyFilter) => {
+          return (
+            <li key={propertyFilter.label}>
+              <button
+                className={`property-list-btn ${
+                  propertyFilter.value ? ".selected" : null
+                }`}
+                onClick={(e) => {
+                  handlePropertyFilters(propertyFilter.value);
+                }}
+              >
+                {propertyFilter.label}
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </>
   );

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -1,21 +1,11 @@
 import React from "react";
-import { fetchProperties } from "../../api";
 
 const Search = ({
   searchTerm,
-  setSearchTerm,
   handleClearSearchTerm,
   handleSearchTerm,
-  setSearchResult
+  searchProperties
 }) => {
-  const searchProperties = (e) => {
-    e.preventDefault();
-    setSearchTerm("");
-    fetchProperties({ address: searchTerm }).then((data) => {
-      setSearchResult(data.properties);
-    });
-  };
-
   return (
     <form onSubmit={searchProperties}>
       <div className="search-wrapper">
@@ -44,9 +34,7 @@ const Search = ({
         </span>
 
         <div className="search-btn-wrapper">
-          <button onClick={searchProperties} className="search-button">
-            Search
-          </button>
+          <button className="search-button">Search</button>
         </div>
       </div>
     </form>

--- a/src/components/SearchResults/index.js
+++ b/src/components/SearchResults/index.js
@@ -1,30 +1,79 @@
 import React from "react";
 import Table from "../Table";
 
-const SearchResults = ({ properties, headingColumns, title }) => {
-  console.log(properties);
-
+const SearchResults = ({
+  properties,
+  filteredPropertyTypes,
+  headingColumns,
+  title,
+  handleCheckBoxClick
+}) => {
   return (
-    <Table headingColumns={headingColumns} title={title}>
-      {properties.map((property) => {
-        return (
-          <tr key={property.id}>
-            <td data-heading={headingColumns[0]}>
-              <input
-                type="checkbox"
-                id={property.id}
-                onChange={(e) => console.log("clicked!")}
-              />
-            </td>
-            <td data-heading={headingColumns[1]}>{property.address}</td>
-            <td data-heading={headingColumns[2]}>{property.postcode}</td>
-            <td data-heading={headingColumns[3]}>{property.propertyType}</td>
-            <td data-heading={headingColumns[4]}>{property.numberOfRooms}</td>
-            <td data-heading={headingColumns[5]}>{property.floorArea}</td>
-          </tr>
-        );
-      })}
-    </Table>
+    <>
+      {properties.length ? (
+        <Table headingColumns={headingColumns} title={title}>
+          {filteredPropertyTypes.length
+            ? filteredPropertyTypes.map((property) => {
+                return (
+                  <tr key={property.id}>
+                    <td data-heading={headingColumns[0]}>
+                      <input
+                        onChange={(e) =>
+                          handleCheckBoxClick(property, e.target.checked)
+                        }
+                        type="checkbox"
+                        id={property.id}
+                      />
+                    </td>
+                    <td data-heading={headingColumns[1]}>{property.address}</td>
+                    <td data-heading={headingColumns[2]}>
+                      {property.postcode}
+                    </td>
+                    <td data-heading={headingColumns[3]}>
+                      {property.propertyType}
+                    </td>
+                    <td data-heading={headingColumns[4]}>
+                      {property.numberOfRooms}
+                    </td>
+                    <td data-heading={headingColumns[5]}>
+                      {property.floorArea}
+                    </td>
+                  </tr>
+                );
+              })
+            : properties.map((property) => {
+                return (
+                  <tr key={property.id}>
+                    <td data-heading={headingColumns[0]}>
+                      <input
+                        onChange={(e) =>
+                          handleCheckBoxClick(property, e.target.checked)
+                        }
+                        type="checkbox"
+                        id={property.id}
+                      />
+                    </td>
+                    <td data-heading={headingColumns[1]}>{property.address}</td>
+                    <td data-heading={headingColumns[2]}>
+                      {property.postcode}
+                    </td>
+                    <td data-heading={headingColumns[3]}>
+                      {property.propertyType}
+                    </td>
+                    <td data-heading={headingColumns[4]}>
+                      {property.numberOfRooms}
+                    </td>
+                    <td data-heading={headingColumns[5]}>
+                      {property.floorArea}
+                    </td>
+                  </tr>
+                );
+              })}
+        </Table>
+      ) : (
+        <h3>Please search for an address to view details</h3>
+      )}
+    </>
   );
 };
 

--- a/src/components/SelectedProperties/index.js
+++ b/src/components/SelectedProperties/index.js
@@ -1,22 +1,31 @@
 import React from "react";
 import Table from "../Table/";
 
-const SelectedProperties = ({ headingColumns, title, properties }) => {
+const SelectedProperties = ({ headingColumns, title, selectedProperties }) => {
   return (
-    <Table title={title} headingColumns={headingColumns}>
-      {/* {properties.map((property) => {
-        return (
-          <tr key={property.id}>
-            <td data-heading={headingColumns[0]}>{property.address}</td>
-            <td data-heading={headingColumns[1]}>{property.postcode}</td>
-            <td data-heading={headingColumns[2]}>{property.propertyType}</td>
-            <td data-heading={headingColumns[3]}>{property.numberOfRooms}</td>
-            <td data-heading={headingColumns[4]}>{property.floorArea}</td>
-          </tr>
-        );
-      })} */}
-      Selected properties will go here
-    </Table>
+    <>
+      {selectedProperties.length ? (
+        <Table title={title} headingColumns={headingColumns}>
+          {selectedProperties.map((property) => {
+            return (
+              <tr key={property.id}>
+                <td data-heading={headingColumns[0]}>{property.address}</td>
+                <td data-heading={headingColumns[1]}>{property.postcode}</td>
+                <td data-heading={headingColumns[2]}>
+                  {property.propertyType}
+                </td>
+                <td data-heading={headingColumns[3]}>
+                  {property.numberOfRooms}
+                </td>
+                <td data-heading={headingColumns[4]}>{property.floorArea}</td>
+              </tr>
+            );
+          })}
+        </Table>
+      ) : (
+        <h3>Selected properties section - No properties selected yet</h3>
+      )}
+    </>
   );
 };
 

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -24,3 +24,9 @@
   font-size: 2rem;
   font-weight: 400;
 }
+
+@media (max-width: 547px) {
+  .header-text {
+    font-size: 1.2rem;
+  }
+}

--- a/src/styles/components/_main.scss
+++ b/src/styles/components/_main.scss
@@ -30,3 +30,21 @@
   grid-column: 1/2;
   grid-row: 3/4;
 }
+
+@media (max-width: 547px) {
+  .main-container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .main-container section:last-child {
+    order: -1;
+  }
+  .main-container section:first-child {
+    order: -1;
+  }
+
+  .types-section {
+    margin-bottom: 20px;
+  }
+}

--- a/src/styles/components/_propertyTypes.scss
+++ b/src/styles/components/_propertyTypes.scss
@@ -8,3 +8,13 @@
   background-color: #f4f5f9;
   align-items: center;
 }
+
+.property-list-btn {
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.selected {
+  font-weight: 800;
+}

--- a/src/useFetch.js
+++ b/src/useFetch.js
@@ -1,0 +1,1 @@
+import { useEffect } from "react";


### PR DESCRIPTION
## Description

This PR creates a selection table that displays marked addresses from the search result section.
Users can also filter addresses by their `Property type` without affecting the selected addresses section.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓| :bug: Bug fix              |
| ✓| :sparkles: New feature     |
| ✓| :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria

Type the full or partial address name in the search field. The search Results section displays addresses associated with the user input and displays it as a table. In order to add an address in the `selected section` press checkmark and observe the changes. 
Users can continue the search process without affecting the selected area. 
In order to filter addresses by the `Property type`, press any of the types displayed on the left of the search results section.